### PR TITLE
Replace outdated Mercurial stuff, update README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-# Use glob syntax:
-syntax: glob
-
 # The local makefile should be ignored:
 Makefile.local
 

--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ GIT            ?= $(shell git status >/dev/null 2>/dev/null && which git 2>/dev/
 PYTHON         ?= python
 
 UNIX2DOS       ?= $(shell which unix2dos 2>/dev/null)
-UNIX2DOS_FLAGS ?= $(shell [ -n $(UNIX2DOS) ] && $(UNIX2DOS) -q --version 2>/dev/null && echo "-q" || echo "")
+UNIX2DOS_FLAGS ?= $(shell [ -n $(UNIX2DOS) ] && $(UNIX2DOS) -q --version 1>&2 2>/dev/null && echo "-q" || echo "")
 
 ################################################################
 # Get the Repository revision, tags and the modified status

--- a/Makefile
+++ b/Makefile
@@ -167,7 +167,7 @@ REPO_BRANCH_STRING ?= $(shell if [ "$(REPO_BRANCH)" = "$(DEFAULT_BRANCH_NAME)" ]
 NEWGRF_VERSION ?= $(shell let x="$(REPO_DAYS_SINCE_2000) + 65536 * $(REPO_BRANCH_VERSION)"; echo "$$x")
 
 # The shown version is either a tag, or in the absence of a tag the revision.
-REPO_VERSION_STRING ?= $(shell echo $(REPO_DATE)$(REPO_BRANCH_STRING) \($(NEWGRF_VERSION):$(REPO_HASH)\))
+REPO_VERSION_STRING ?= $(shell [ -n "$(REPO_TAGS)" ] && echo $(REPO_TAGS) || echo $(REPO_DATE)$(REPO_BRANCH_STRING) \($(NEWGRF_VERSION):$(REPO_HASH)\))
 
 # The title consists of name and version
 REPO_TITLE     ?= $(REPO_NAME) $(REPO_VERSION_STRING)

--- a/Makefile.in
+++ b/Makefile.in
@@ -32,7 +32,7 @@ $(BASE_FILENAME).obm: $(LANG_FILES) $(MIDI_FILES) $(THEMES_FILE) Makefile Makefi
 	@echo "" >> $@
 	@echo "[origin]" >> $@
 	@echo "$(REPO_ORIGIN)" >> $@
-	$(_E) "[Done] Basesound successfully generated."
+	$(_E) "[Done] Basemusic successfully generated."
 	$(_E) ""
 
 music: $(BASE_FILENAME).obm

--- a/Makefile.local.sample
+++ b/Makefile.local.sample
@@ -76,7 +76,7 @@
 # BZIP           = bzip2
 # CC             = gcc
 # AWK            = awk
-# HG             = hg
+# GIT            = git
 # MAKE           = make
 # UNIX2DOS       = $(shell [ `which unix2dos 2>/dev/null` ] && echo "unix2dos" || echo "")
 # MD5SUM         = $(shell [ "$(OSTYPE)" = "Darwin" ] && echo "md5 -r" || echo "md5sum")

--- a/docs/readme.ptxt
+++ b/docs/readme.ptxt
@@ -36,85 +36,97 @@ OpenMSX is an open source Music Set for OpenTTD.
 
     b) Manually:
         download the latest OpenMSX package from its development homepage:
-        homepage http://dev.openttdcoop.org/openmsx
-        Unpack the zip file into the OpenTTD baseset directory (see section 4.2
+        homepage: https://github.com/OpenTTD/OpenMSX
+        Unpack the zip file into the OpenTTD 'baseset' directory (see section 4.2
         of the OpenTTD readme for a detailed treatise on all data dirs OpenTTD
         recognizes).
         - An OpenTTD folder in your user account's home directory:
-        	Windows:
-        	  C:\My Documents (95, 98, ME)
-            C:\Documents and Settings\<username>\My Documents\OpenTTD (2000, XP)
-            C:\Users\<username>\Documents\OpenTTD (Vista, 7)
-          Mac OSX: ~/Documents/OpenTTD
-          Linux:   ~/.openttd
+            Windows:
+              C:\My Documents (95, 98, ME)
+              C:\Documents and Settings\<username>\My Documents\OpenTTD (2000, XP)
+              C:\Users\<username>\Documents\OpenTTD (Vista, 7)
+          macOS:     ~/Documents/OpenTTD
+          GNU/Linux: ~/.openttd
         - The OpenTTD installation directory.
 
-3. In the main menu of the game, click the Game Options  button. The Game
-   Options  dialog will appear.
+3. In the main menu of the game, click the Game Options button. The Game
+   Options dialog will appear.
 
-4. Select OpenMSX  from the drop-down list below Base Music set if that's not
+4. Select OpenMSX from the drop-down list below Base Music set if that's not
    selected already (bottom left of window). Close the window using the × in the
    upper left corner.
 
    Now that wasn't so hard, was it? Anyways, if you're having trouble getting
    OpenMSX to work, please file a detailed report on what you did, what error
    messages you got and where you got stuck at our bug tracker at
-   http://dev.openttdcoop.org/projects/openmsx or in the tt-forums.
+       https://github.com/OpenTTD/OpenSFX/issues
+   or at
+       https://www.tt-forums.net
 
+5. Music might not start automatically. If music does not play yet,
+   start a game and open the music box from the toolbar.
+   Here you can control the volume, and start and stop the music.
 
 
 2 Troubleshooting and bad sound output
 ======================================
 
+(Windows)
 Depending upon the hardware and the music driver used, OpenTTD may have problems
 to playback some songs without error or that it may happen that subsequent sound
 output is changed in a detrimental way. The latter is especially know to happen
 with the windows "dmusic" sound driver. You may want to try the "win32" music
-driver, if you have problems with windows' default dmusic driver. Search your
+driver, if you have problems with Windows' default dmusic driver. Search your
 openttd.cfg for "musicdriver" and change the line to "musidriver = win32".
 Consult also the OpenTTD readme for available options and its known-bugs.txt
-for a more detailed and possibly more up to date description of windows music
+for a more detailed and possibly more up to date description of Windows music
 driver issues.
 
+(GNU/Linux)
+If you cannot get music to play, it might be because your system does not
+support MIDI playback yet.
+Please refer to the manual of your Linux distribution to learn about how
+to get MIDI files to play. We recommend to install TiMidity++.
 
 
 3 Contributing and compiling from source
 ========================================
 
-The OpenMSX source is available in a Mercurial repository or as gzip'ed tarball.
-You can do an anonymous checkout from http://mz.openttdcoop.org/hg/openmsx ,
+The OpenMSX source is available in a Git repository or as gzip'ed tarball.
+You can do a clone from
+   https://github.com/OpenTTD/OpenMSX
 e.g. using
-   hg clone http://mz.openttdcoop.org/hg/openmsx or obtain the tarball from
-http://bundles.openttdcoop.org/openmsx/releases.
+   git clone https://github.com/OpenTTD/OpenMSX
+or obtain the tarball from
+   https://www.openttd.org/downloads/openmsx-releases/latest.html
 
 Prerequisites to building OpenMSX:
-- mercurial (only when not building from a tarball, available from
-http://mercurial.selenic.com/wiki/Download?action=show&redirect=BinaryPackages)
-- md5sum (linux, mingw) or md5 (mac)
-- some gnu utils: make, cat, sed
+- Git (only when not building from a tarball)
+- md5sum (Linux, MinGW) or md5 (macOS)
+- some GNU utils: make, cat, sed
 - unix2dos for convenient conversion of the text files
-- python (if you use mercurial, you'll have python)
+- Python
 and you might additionally want a text editor of your choice and possibly a
 programme capable of creating and editing midi files.
 
-On Windows: we advise to get a mingw development environment, download mercurial
-from the sources mentioned above) For more detailed instructions see our guide
+On Windows: We advise to get a MinGW development environment.
+For more detailed instructions, see our guide
 at http://dev.openttdcoop.org/projects/home/wiki and the very extensive and
-detailed installation instructions on the mingw wiki at
+detailed installation instructions on the MinGW wiki at
 http://www.mingw.org/wiki/Getting_Started
 
-On Linux: your system should already have most tools, you'll probably only
-mercurial available from the source mentioned above. For installation
-instructions concerning mercurial refer to the manual of your distribution.
+On GNU/Linux: Your system should already have most tools, you'll probably only
+Git available from the source mentioned above. For installation
+instructions concerning Git, refer to the manual of your distribution.
 
-On Mac: Install the developers tools. Mercurial is easiest insalled via
-macports: sudo port install mercurial
+On macOS: Install the developers tools. Git is easiest insalled via
+macports: sudo port install git
 
-The use of mercurial is strongly encouraged as only that allows to keep track of
+The use of Git is strongly encouraged as only that allows to keep track of
 changes.
 
 Once all tools are installed, get a checkout of the repository and you can build
-OpenMSX using make. The following targets are available:
+OpenMSX using 'make'. The following targets are available:
 - all: builds all grfs and the obm file
 - install: build and then copy OpenMSX in your OpenTTD music directory. Use
 Makefile.local to specify a different path

--- a/docs/readme.ptxt
+++ b/docs/readme.ptxt
@@ -59,7 +59,7 @@ OpenMSX is an open source Music Set for OpenTTD.
    Now that wasn't so hard, was it? Anyways, if you're having trouble getting
    OpenMSX to work, please file a detailed report on what you did, what error
    messages you got and where you got stuck at our bug tracker at
-       https://github.com/OpenTTD/OpenSFX/issues
+       https://github.com/OpenTTD/OpenMSX/issues
    or at
        https://www.tt-forums.net
 
@@ -86,7 +86,7 @@ driver issues.
 If you cannot get music to play, it might be because your system does not
 support MIDI playback yet.
 Please refer to the manual of your Linux distribution to learn about how
-to get MIDI files to play. We recommend to install TiMidity++.
+to get MIDI files to play.
 
 
 3 Contributing and compiling from source
@@ -115,9 +115,9 @@ at http://dev.openttdcoop.org/projects/home/wiki and the very extensive and
 detailed installation instructions on the MinGW wiki at
 http://www.mingw.org/wiki/Getting_Started
 
-On GNU/Linux: Your system should already have most tools, you'll probably only
-Git available from the source mentioned above. For installation
-instructions concerning Git, refer to the manual of your distribution.
+On GNU/Linux: Your system probably has most of these things installed,
+but if not, all of these things should be easy to install if your system
+has a software package manager.
 
 On macOS: Install the developers tools. Git is easiest installed via
 macports: sudo port install git

--- a/docs/readme.ptxt
+++ b/docs/readme.ptxt
@@ -1,7 +1,7 @@
 OpenMSX Readme - An OpenTTD Music replacement set
 
 ===============================
-Current Version: {{REPO_TITLE}}
+Current Version: {{GRF_TITLE}}
 ===============================
 
 Contents

--- a/docs/readme.ptxt
+++ b/docs/readme.ptxt
@@ -119,7 +119,7 @@ On GNU/Linux: Your system should already have most tools, you'll probably only
 Git available from the source mentioned above. For installation
 instructions concerning Git, refer to the manual of your distribution.
 
-On macOS: Install the developers tools. Git is easiest insalled via
+On macOS: Install the developers tools. Git is easiest installed via
 macports: sudo port install git
 
 The use of Git is strongly encouraged as only that allows to keep track of

--- a/findversion.sh
+++ b/findversion.sh
@@ -1,0 +1,113 @@
+#!/bin/sh
+
+# This file is part of OpenTTD.
+# OpenTTD is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+# OpenTTD is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with OpenTTD. If not, see <http://www.gnu.org/licenses/>.
+
+
+# Arguments given? Show help text.
+if [ "$#" != "0" ]; then
+	cat <<EOF
+Usage: ./findversion.sh
+Finds the current revision and if the code is modified.
+
+Output: <VERSION>\t<ISODATE>\t<MODIFIED>\t<HASH>
+VERSION
+    a string describing what version of the code the current checkout is
+    based on.
+    This also includes the commit date, an indication of whether the checkout
+    was modified and which branch was checked out. This value is not
+    guaranteed to be sortable, but is mainly meant for identifying the
+    revision and user display.
+
+    If no revision identifier could be found, this is left empty.
+ISODATE
+    the commit date of the revision this checkout is based on.
+    The commit date may differ from the author date.
+    This can be used to decide upon the age of the source.
+
+    If no timestamp could be found, this is left empty.
+MODIFIED
+    Whether (the src directory of) this checkout is modified or not. A
+    value of 0 means not modified, a value of 2 means it was modified.
+
+    A value of 1 means that the modified status is unknown, because this
+    is not an git checkout for example.
+
+HASH
+    the git revision hash
+
+By setting the AWK environment variable, a caller can determine which
+version of "awk" is used. If nothing is set, this script defaults to
+"awk".
+EOF
+exit 1;
+fi
+
+# Allow awk to be provided by the caller.
+if [ -z "$AWK" ]; then
+	AWK=awk
+fi
+
+# Find out some dirs
+cd `dirname "$0"`
+ROOT_DIR=`pwd`
+
+# Determine if we are using a modified version
+# Assume the dir is not modified
+MODIFIED="0"
+if [ -d "$ROOT_DIR/.git" ] || [ -f "$ROOT_DIR/.git" ]; then
+	# We are a git checkout
+	# Refresh the index to make sure file stat info is in sync, then look for modifications
+	git update-index --refresh >/dev/null
+	if [ -n "`git diff-index HEAD`" ]; then
+		MODIFIED="2"
+	fi
+	HASH=`LC_ALL=C git rev-parse --verify HEAD 2>/dev/null`
+	SHORTHASH=`echo ${HASH} | cut -c1-10`
+	ISODATE=`LC_ALL=C git show -s --pretty='format:%ci' HEAD | "$AWK" '{ gsub("-", "", $1); print $1 }'`
+	BRANCH="`git symbolic-ref -q HEAD 2>/dev/null | sed 's@.*/@@'`"
+	TAG="`git name-rev --name-only --tags --no-undefined HEAD 2>/dev/null | sed 's@\^0$@@'`"
+
+	if [ "$MODIFIED" -eq "0" ]; then
+		hashprefix="-g"
+	elif [ "$MODIFIED" -eq "2" ]; then
+		hashprefix="-m"
+	else
+		hashprefix="-u"
+	fi
+
+	if [ -n "$TAG" ]; then
+		VERSION="${TAG}"
+		ISTAG="1"
+		if [ -n "`echo \"${TAG}\" | grep \"^[0-9.]*$\"`" ]; then
+			ISSTABLETAG="1"
+		else
+			ISSTABLETAG="0"
+		fi
+	else
+		VERSION="${ISODATE}-${BRANCH}${hashprefix}${SHORTHASH}"
+		ISTAG="0"
+		ISSTABLETAG="0"
+	fi
+
+elif [ -f "$ROOT_DIR/.ottdrev" ]; then
+	# We are an exported source bundle
+	cat $ROOT_DIR/.ottdrev
+	exit
+else
+	# We don't know
+	MODIFIED="1"
+	HASH=""
+	SHORTHASH=""
+	BRANCH=""
+	ISODATE=""
+	TAG=""
+	VERSION=""
+	ISTAG="0"
+	ISSTABLETAG="0"
+fi
+
+echo "$VERSION	$ISODATE	$MODIFIED	$HASH	$ISTAG	$ISSTABLETAG"
+


### PR DESCRIPTION
Fixes #5. Fixes #6.

This PR updates the README and fixes many outdated instructions, links and references to Mercurial-related stuff to replace it with Git-related stuff.

This PR also updates the Makefiles and `.hgignore`.