### PR TITLE
Change: Stop calling OpenMSX a 'replacement'

### DIFF
--- a/docs/readme.ptxt
+++ b/docs/readme.ptxt
@@ -1,4 +1,5 @@
-OpenMSX Readme - An OpenTTD Music replacement set
+OpenMSX - base music set for OpenTTD
+Readme
 
 ===============================
 Current Version: {{GRF_TITLE}}
@@ -17,7 +18,7 @@ Contents
 0 About OpenMSX
 ===============
 
-OpenMSX is an open source Music Set for OpenTTD.
+OpenMSX is an open source base music set for OpenTTD.
 
 
 
@@ -150,7 +151,7 @@ Mind to re-start OpenTTD as it needs to re-read the files.
 4 License
 =========
 
-OpenMSX Music Replacement Set for OpenTTD Copyright (C) 2010 OpenMSX Authors
+The OpenMSX music set for OpenTTD Copyright (C) 2010-2021 OpenMSX Authors
 (see below or in the source in themes.list) and is licensed under GPL v2.
 
 This program is free software; you can redistribute it and/or modify it under

--- a/lang/english.lng
+++ b/lang/english.lng
@@ -1,3 +1,3 @@
 ##grflangid 0x01
-STR_GENERAL_DESC        :OpenMSX music replacement set for OpenTTD. Freely available under the terms of the GPL v2. For full credits see "readme.txt" [{TITLE}]
+STR_GENERAL_DESC        :OpenMSX base music set for OpenTTD. Freely available under the terms of the GPL v2. For full credits see "readme.txt" [{TITLE}]
 


### PR DESCRIPTION
Someone complained in IRC that OpenSFX/OpenMSX is called a 'replacement' which is severely underselling this base set. And I agree, it should not be called a 'replacement', it is perfectly valid in its own right.

This PR will change the description and README. Note the description file is changed, which means the translations (of which there are a LOT!) have to be reset. :-( Feel free to reject if you don't want to reset the translations.