### PR TITLE
Codechange: [DorpsGek] Also announce tags

### DIFF
--- a/.dorpsgek.yml
+++ b/.dorpsgek.yml
@@ -1,9 +1,9 @@
 notifications:
   global:
     irc:
-      - openttd
-      - openttd.notice
+    - openttd
+    - openttd.notice
 
-  commit-comment:
   pull-request:
   issue:
+  tag-created:


### PR DESCRIPTION
Turns out tags weren't announced. Copy DorpsGek config from OpenSFX (which pulls in some other changes..)